### PR TITLE
serve_static_file: redirect /dir => /dir/

### DIFF
--- a/include/net/web_server/responses.h
+++ b/include/net/web_server/responses.h
@@ -32,4 +32,10 @@ web_server::empty_res_t empty_response(
     boost::beast::http::status status = boost::beast::http::status::ok,
     std::string_view content_type = "text/html");
 
+web_server::string_res_t moved_response(
+    web_server::http_req_t const& req, std::string_view new_location,
+    boost::beast::http::status status =
+        boost::beast::http::status::moved_permanently,
+    std::string_view content_type = "text/html");
+
 }  // namespace net

--- a/src/web_server/responses.cc
+++ b/src/web_server/responses.cc
@@ -48,4 +48,18 @@ web_server::empty_res_t empty_response(web_server::http_req_t const& req,
   return res;
 }
 
+web_server::string_res_t moved_response(web_server::http_req_t const& req,
+                                        std::string_view new_location,
+                                        boost::beast::http::status status,
+                                        std::string_view content_type) {
+  web_server::string_res_t res{status, req.version()};
+  res.set(http::field::server, BOOST_BEAST_VERSION_STRING);
+  res.set(http::field::content_type, content_type);
+  res.set(http::field::location, new_location);
+  res.keep_alive(req.keep_alive());
+  res.body() = http::obsolete_reason(status);
+  res.prepare_payload();
+  return res;
+}
+
 }  // namespace net


### PR DESCRIPTION
If the request target doesn't have a trailing slash but is a directory, redirect to the target with a trailing slash added.

Examples:

- `/test` => `/test/`
- `/test?foo=bar` => `/test/?foo=bar`