### PR TITLE
fix: avoid duplicating "Content-Length" header

### DIFF
--- a/src/http/client/client.cc
+++ b/src/http/client/client.cc
@@ -28,11 +28,6 @@ basic_http_client<C>::basic_http_client(
 
 template <typename C>
 void basic_http_client<C>::query(request& req, callback cb) {
-  if (!req.body.empty()) {
-    auto content_length = std::to_string(req.body.length());
-    req.headers.insert(std::make_pair("content-length", content_length));
-  }
-
   request_ = req.to_str();
 
   static_cast<C*>(this)->connect([this, cb](auto&& v1, auto&& v2) {


### PR DESCRIPTION
Duplicated "Content-Length" header causes certain clients to respond with a 400-type error. This issue is addressed by removing the first insertion of the header while keeping the downstream occurrence in the `request::to_str()` function. 
https://github.com/motis-project/net/blob/785b39c08212732e510305f0eef18de70f19b15e/src/http/client/request.cc#L64-L67