### PR TITLE
fix web server crash when connection with pending requests is closed

### DIFF
--- a/src/web_server/http_session.cc
+++ b/src/web_server/http_session.cc
@@ -350,7 +350,8 @@ struct ssl_http_session
     boost::beast::get_lowest_layer(stream_).expires_after(settings_->timeout_);
 
     // Perform the SSL shutdown
-    stream_.async_shutdown(ssl_http_session::on_shutdown);
+    stream_.async_shutdown(boost::beast::bind_front_handler(
+        &ssl_http_session::on_shutdown, shared_from_this()));
   }
 
   static bool is_ssl() { return true; }
@@ -368,7 +369,7 @@ private:
     do_read();
   }
 
-  static void on_shutdown(boost::beast::error_code ec) {
+  void on_shutdown(boost::beast::error_code ec) {
     if (ec) {
       closed_ = true;
       return fail(ec, "shutdown");


### PR DESCRIPTION
To reproduce the bug:
- Set the server timeout to a low value: `s.set_timeout(std::chrono::seconds{5});`
- In a request handler sleep for longer than the timeout: `std::this_thread::sleep_for(std::chrono::seconds{10});`
- Once the request handler tries to send its response, the server crashes

The `boost::beast::http::async_write` call causes a bad executor asio exception if the stream has been closed. We now store whether the stream has been closed before trying to write the response.
