### PR TITLE
Add methods to set headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(net)
+project(net LANGUAGES C CXX ASM)
 
 if(NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/include/net/web_server/query_router.h
+++ b/include/net/web_server/query_router.h
@@ -193,8 +193,7 @@ struct query_router {
                   bool is_ssl);
   void reply_hook(std::function<void(reply&)> reply_hook);
   void enable_cors();
-  query_router& add_header(std::string key, std::string value) &;
-  query_router&& add_header(std::string key, std::string value) &&;
+  void add_header(std::string key, std::string value);
   void serve_files(std::filesystem::path const& p);
 
 private:

--- a/include/net/web_server/query_router.h
+++ b/include/net/web_server/query_router.h
@@ -193,6 +193,8 @@ struct query_router {
                   bool is_ssl);
   void reply_hook(std::function<void(reply&)> reply_hook);
   void enable_cors();
+  query_router& add_header(std::string key, std::string value) &;
+  query_router&& add_header(std::string key, std::string value) &&;
   void serve_files(std::filesystem::path const& p);
 
 private:

--- a/src/web_server/query_router.cc
+++ b/src/web_server/query_router.cc
@@ -125,8 +125,8 @@ void query_router<Executor>::operator()(web_server::http_req_t req,
         }
         // Add headers
         std::visit(
-            [&headers = impl_->headers_](auto& r) {
-              for (auto& header : headers) {
+            [&](auto& r) {
+              for (auto const& header : impl_->headers) {
                 r.set(header.key_, header.value_);
               }
             },

--- a/src/web_server/query_router.cc
+++ b/src/web_server/query_router.cc
@@ -151,7 +151,7 @@ void query_router<Executor>::enable_cors() {
 
 template <typename Executor>
 void query_router<Executor>::add_header(std::string key, std::string value) {
-  impl_->headers_.emplace_back(std::move(key), std::move(value));
+  impl_->headers_.emplace_back(header{std::move(key), std::move(value)});
 }
 
 template <typename Executor>

--- a/src/web_server/query_router.cc
+++ b/src/web_server/query_router.cc
@@ -28,6 +28,11 @@
 
 namespace net {
 
+struct header {
+  std::string key_;
+  std::string value_;
+};
+
 struct handler {
   std::string method_;
   std::string prefix_;
@@ -40,6 +45,7 @@ asio_exec::asio_exec(boost::asio::io_context& io,
 
 template <typename Executor>
 struct query_router<Executor>::impl {
+  std::vector<header> headers_;
   std::vector<handler> routes_;
   std::function<void(reply&)> reply_hook_;
 };
@@ -117,6 +123,14 @@ void query_router<Executor>::operator()(web_server::http_req_t req,
             std::cerr << "query_router: unhandled exception in reply hook\n";
           }
         }
+        // Add headers
+        std::visit(
+            [&headers = impl_->headers_](auto& r) {
+              for (auto& header : headers) {
+                r.set(header.key_, header.value_);
+              }
+            },
+            rep);
         return std::move(rep);
       },
       std::move(cb));
@@ -133,6 +147,20 @@ void query_router<Executor>::enable_cors() {
   reply_hook([](reply& rep) { net::enable_cors(rep); });
   route("OPTIONS", "",
         [](route_request const& req, bool) { return empty_response(req); });
+}
+
+template <typename Executor>
+query_router<Executor>& query_router<Executor>::add_header(
+    std::string key, std::string value) & {
+  impl_->headers_.emplace_back(std::move(key), std::move(value));
+  return *this;
+}
+
+template <typename Executor>
+query_router<Executor>&& query_router<Executor>::add_header(
+    std::string key, std::string value) && {
+  impl_->headers_.emplace_back(std::move(key), std::move(value));
+  return std::move(*this);
 }
 
 template <typename Executor>

--- a/src/web_server/query_router.cc
+++ b/src/web_server/query_router.cc
@@ -151,7 +151,7 @@ void query_router<Executor>::enable_cors() {
 
 template <typename Executor>
 void query_router<Executor>::add_header(std::string key, std::string value) {
-  impl_->headers_.emplace_back(header{std::move(key), std::move(value)});
+  impl_->headers_.push_back(header{std::move(key), std::move(value)});
 }
 
 template <typename Executor>

--- a/src/web_server/query_router.cc
+++ b/src/web_server/query_router.cc
@@ -150,17 +150,8 @@ void query_router<Executor>::enable_cors() {
 }
 
 template <typename Executor>
-query_router<Executor>& query_router<Executor>::add_header(
-    std::string key, std::string value) & {
+void query_router<Executor>::add_header(std::string key, std::string value) {
   impl_->headers_.emplace_back(std::move(key), std::move(value));
-  return *this;
-}
-
-template <typename Executor>
-query_router<Executor>&& query_router<Executor>::add_header(
-    std::string key, std::string value) && {
-  impl_->headers_.emplace_back(std::move(key), std::move(value));
-  return std::move(*this);
 }
 
 template <typename Executor>

--- a/src/web_server/query_router.cc
+++ b/src/web_server/query_router.cc
@@ -126,7 +126,7 @@ void query_router<Executor>::operator()(web_server::http_req_t req,
         // Add headers
         std::visit(
             [&](auto& r) {
-              for (auto const& header : impl_->headers) {
+              for (auto const& header : impl_->headers_) {
                 r.set(header.key_, header.value_);
               }
             },


### PR DESCRIPTION
This adds `query_router::add_header(key, value)`, that can be used to set or change headers sent. These headers will be added to all responses.

Example responses:

```sh
$ curl -I -X GET 'localhost:8080/'
HTTP/1.1 200 OK
Content-Type: text/html
Content-Length: 17604
Access-Control-Allow-Origin: *
Access-Control-Allow-Headers: *
Access-Control-Allow-Methods: GET, POST, OPTIONS
Server: v2.0.15-dirty
```