### PR TITLE
Web Server: Fix static file checks

### DIFF
--- a/include/net/web_server/serve_static.h
+++ b/include/net/web_server/serve_static.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <filesystem>
+
 #include "boost/beast/core/string.hpp"
 
 #include "net/web_server/web_server.h"
@@ -7,6 +9,9 @@
 namespace net {
 
 std::optional<web_server::http_res_t> serve_static_file(
+    std::filesystem::path const& doc_root, web_server::http_req_t const& req);
+
+std::optional<web_server::http_res_t> serve_static_file(
     boost::beast::string_view doc_root, web_server::http_req_t const& req);
 
-}
+}  // namespace net

--- a/src/web_server/query_router.cc
+++ b/src/web_server/query_router.cc
@@ -158,8 +158,7 @@ template <typename Executor>
 void query_router<Executor>::serve_files(std::filesystem::path const& p) {
   route("GET", "",
         [p](route_request const& req, bool) -> web_server::http_res_t {
-          if (auto res = serve_static_file(p.generic_string(), req);
-              res.has_value()) {
+          if (auto res = serve_static_file(p, req); res.has_value()) {
             return std::move(*res);
           } else {
             namespace http = boost::beast::http;

--- a/src/web_server/serve_static.cc
+++ b/src/web_server/serve_static.cc
@@ -97,7 +97,8 @@ std::optional<web_server::http_res_t> serve_static_file(
 
   auto path = doc_root;
   for (auto const& seg : url.segments()) {
-    if (seg.empty() || seg == "." || seg == "..") {
+    if (seg.empty() || seg == "." || seg == ".." ||
+        seg.find(":") != std::string::npos) {
       return bad_request_response(req, "Invalid target");
     }
     path /= std::u8string{seg.begin(), seg.end()};

--- a/src/web_server/serve_static.cc
+++ b/src/web_server/serve_static.cc
@@ -6,7 +6,6 @@
 #include "boost/url.hpp"
 
 #include "net/web_server/responses.h"
-#include "net/web_server/url_decode.h"
 
 namespace beast = boost::beast;
 namespace http = boost::beast::http;
@@ -14,15 +13,8 @@ namespace fs = std::filesystem;
 
 namespace net {
 
-inline std::string_view mime_type(beast::string_view path) {
+inline std::string_view mime_type(beast::string_view ext) {
   using beast::iequals;
-  auto const ext = [&path] {
-    auto const pos = path.rfind('.');
-    if (pos == beast::string_view::npos) {
-      return beast::string_view{};
-    }
-    return path.substr(pos);
-  }();
   if (iequals(ext, ".js") || iequals(ext, ".mjs")) {
     return "application/javascript";
   }
@@ -80,37 +72,11 @@ inline std::string_view mime_type(beast::string_view path) {
   return " application/octet-stream";
 }
 
-std::string path_cat(beast::string_view base, beast::string_view path) {
-  if (base.empty()) {
-    return std::string(path);
-  }
-  std::string result(base);
-#ifdef BOOST_MSVC
-  char constexpr path_separator = '\\';
-  if (result.back() == path_separator) {
-    result.resize(result.size() - 1);
-  }
-  result.append(path.data(), path.size());
-  for (auto& c : result) {
-    if (c == '/') {
-      c = path_separator;
-    }
-  }
-#else
-  char constexpr path_separator = '/';
-  if (result.back() == path_separator) {
-    result.resize(result.size() - 1);
-  }
-  result.append(path.data(), path.size());
-#endif
-  return result;
-}
-
 std::optional<web_server::http_res_t> handle_directory_redirect(
-    std::string const& path, web_server::http_req_t const& req,
+    fs::path const& path, web_server::http_req_t const& req,
     boost::urls::url_view const& url) {
   boost::system::error_code sys_ec;
-  auto const file_status = fs::status(fs::path{path}, sys_ec);
+  auto const file_status = fs::status(path, sys_ec);
   if (!sys_ec.failed() && fs::is_directory(file_status)) {
     auto new_target = boost::urls::url{url};
     new_target.set_path(url.path() + "/");
@@ -121,21 +87,23 @@ std::optional<web_server::http_res_t> handle_directory_redirect(
 }
 
 std::optional<web_server::http_res_t> serve_static_file(
-    beast::string_view doc_root, web_server::http_req_t const& req) {
+    fs::path const& doc_root, web_server::http_req_t const& req) {
   if (req.method() != http::verb::get && req.method() != http::verb::head) {
     return bad_request_response(req, "Invalid method");
   }
 
   auto const url = boost::urls::url_view{req.target()};
   auto const url_path = url.path();
-  if (url_path.empty() || url_path[0] != '/' ||
-      url_path.find("..") != beast::string_view::npos) {
-    return bad_request_response(req, "Invalid target");
-  }
 
-  auto path = path_cat(doc_root, url_path);
+  auto path = doc_root;
+  for (auto const& seg : url.segments()) {
+    if (seg.empty() || seg == "." || seg == "..") {
+      return bad_request_response(req, "Invalid target");
+    }
+    path /= std::u8string{seg.begin(), seg.end()};
+  }
   if (url_path.back() == '/') {
-    path.append("index.html");
+    path /= "index.html";
   }
 
   if (auto res = handle_directory_redirect(path, req, url); res.has_value()) {
@@ -144,7 +112,8 @@ std::optional<web_server::http_res_t> serve_static_file(
 
   boost::beast::error_code ec;
   http::file_body::value_type body;
-  body.open(path.c_str(), beast::file_mode::scan, ec);
+  body.open(reinterpret_cast<char const*>(path.u8string().c_str()),
+            beast::file_mode::scan, ec);
 
   if (ec == beast::errc::no_such_file_or_directory) {
     return std::nullopt;
@@ -153,7 +122,8 @@ std::optional<web_server::http_res_t> serve_static_file(
   }
 
   auto const size = body.size();
-  auto const content_type = mime_type(path);
+  auto const ext = path.extension().string();
+  auto const content_type = mime_type(ext);
 
   if (req.method() == http::verb::head) {
     auto res = empty_response(req, http::status::ok, content_type);
@@ -167,6 +137,12 @@ std::optional<web_server::http_res_t> serve_static_file(
     res.content_length(size);
     return res;
   }
+}
+
+std::optional<web_server::http_res_t> serve_static_file(
+    beast::string_view doc_root, web_server::http_req_t const& req) {
+  return serve_static_file(fs::path{static_cast<std::string_view>(doc_root)},
+                           req);
 }
 
 }  // namespace net


### PR DESCRIPTION
Fixes so that URLs containing ".." or ":" are correctly rejected when serving static files.