### PR TITLE
Web Server: More static file checks

### DIFF
--- a/src/web_server/serve_static.cc
+++ b/src/web_server/serve_static.cc
@@ -98,7 +98,9 @@ std::optional<web_server::http_res_t> serve_static_file(
   auto path = doc_root;
   for (auto const& seg : url.segments()) {
     if (seg.empty() || seg == "." || seg == ".." ||
-        seg.find(":") != std::string::npos) {
+        seg.find(":") != std::string::npos ||
+        seg.find("/") != std::string::npos ||
+        seg.find("\\") != std::string::npos) {
       return bad_request_response(req, "Invalid target");
     }
     path /= std::u8string{seg.begin(), seg.end()};


### PR DESCRIPTION
Fixes some cases that #27 missed (e.g. URLs with `/%2F`).

Also checks that all resolved static file paths are in the web root (symlinks to files outside the web root are no longer allowed).